### PR TITLE
Fix workflow permissions for sync-labels

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 jobs:
   build:


### PR DESCRIPTION
Add missing permissions required by actions in this workflow.